### PR TITLE
add item as the last argument in callCallback

### DIFF
--- a/src/components/Vuetable.vue
+++ b/src/components/Vuetable.vue
@@ -618,8 +618,8 @@ export default {
 
             if (typeof this.$parent[func] == 'function') {
                 return (args.length > 0)
-                    ? this.$parent[func].apply(this.$parent, [this.getObjectValue(item, field.name)].concat(args))
-                    : this.$parent[func].call(this.$parent, this.getObjectValue(item, field.name))
+                    ? this.$parent[func].apply(this.$parent, [this.getObjectValue(item, field.name)].concat(args, item))
+                    : this.$parent[func].call(this.$parent, this.getObjectValue(item, field.name), item)
             }
 
             return null


### PR DESCRIPTION
sometimes we need get the other property of one item when rendering it (rendering happend in callCallback).

As of example below, value is the `create_time` property of the item and means the date 2016.08.25 , the item has another property `end_time` means the date 2016.08.26

I want to show data as format `[item.create_time] ~ [item.end_time]`,
for example, '2016-08-25 ~ 2016-08-26', but I cannot get the end_time property directly with Vuetable@1.4.1

```
formatSEtime (value) {
  value = toLocalDateStr(value, 'YYYY-MM-DD') //  I can just render the create_time
  return value
},
```

(toLocalDateStr can format date Object or unix timestamp)

the pull request add the item to the last argument of `callback` function of column's definition,
thus, we can get any other rest properties of the item.

```
formatSEtime (value, item) {
  let start_time = toLocalDateStr(value, 'YYYY-MM-DD')
  let end_time = toLocalDateStr(item.end_time, 'YYYY-MM-DD')
  return `${start_time} ~ ${end_time}`
},
```
