### PR TITLE
replace response.data with response.body

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Then, reference the vuetable via `<vuetable>` tag as following
 					'lastname',
 					'nickname',
 					'birthdate',
-					'group.name_en'
+					'group.name_en',
 					'gender',
 					'last_login',
 					'__actions'

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "vue.js table component that will automatically request JSON data from server and display them nicely in HTML table with swap-able/extensible pagination component",
   "main": "dist/vue-table.js",
   "dependencies": {
-    "vue": "~1.0.21",
-    "vue-resource": "~0.7"
+    "vue": "^1.0.26",
+    "vue-resource": "^1.0.2"
   },
   "directories": {
     "example": "examples"

--- a/src/components/Vuetable.vue
+++ b/src/components/Vuetable.vue
@@ -423,8 +423,8 @@ export default {
             var url = this.apiUrl + '?' + this.getAllQueryParams()
             this.$http.get(url, this.httpData, this.httpOptions)
                 .then(function(response) {
-                    self.tableData = self.getObjectValue(response.json(), self.dataPath, null)
-                    self.tablePagination = self.getObjectValue(response.json(), self.paginationPath, null)
+                    self.tableData = self.getObjectValue(response.body, self.dataPath, null)
+                    self.tablePagination = self.getObjectValue(response.body, self.paginationPath, null)
                     if (self.tablePagination === null) {
                         console.warn('vuetable: pagination-path "' + self.paginationPath + '" not found. '
                             + 'It looks like the data returned from the sever does not have pagination information '

--- a/src/components/Vuetable.vue
+++ b/src/components/Vuetable.vue
@@ -423,8 +423,8 @@ export default {
             var url = this.apiUrl + '?' + this.getAllQueryParams()
             this.$http.get(url, this.httpData, this.httpOptions)
                 .then(function(response) {
-                    self.tableData = self.getObjectValue(response.data, self.dataPath, null)
-                    self.tablePagination = self.getObjectValue(response.data, self.paginationPath, null)
+                    self.tableData = self.getObjectValue(response.json(), self.dataPath, null)
+                    self.tablePagination = self.getObjectValue(response.json(), self.paginationPath, null)
                     if (self.tablePagination === null) {
                         console.warn('vuetable: pagination-path "' + self.paginationPath + '" not found. '
                             + 'It looks like the data returned from the sever does not have pagination information '


### PR DESCRIPTION
response.data no longer exists in vue-resource. you can now access the json body of the request via response.json() (see https://github.com/vuejs/vue-resource/blob/master/docs/api.md#response)

I updated the loadData method to reflect the change.

Please note that this will be a breaking change. old vue-resource versions will no longer be supported.
