### PR TITLE
adds new event 'vuetable:normalize-fields'

### DIFF
--- a/src/components/Vuetable.vue
+++ b/src/components/Vuetable.vue
@@ -901,6 +901,9 @@ export default {
         },
         'vuetable:hide-detail': function(dataItem) {
             this.hideDetailRow(dataItem)
+        },
+        'vuetable:normalize-fields': function() {
+            this.normalizeFields()
         }
     },
     created: function() {


### PR DESCRIPTION
This event can be used, to trigger the `normalizeFields()`-method. This event should be triggered after the `fields` properties changes, so that the table renders correctly. This resolves #146. 