### PR TITLE
Update jsDelivr links

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,12 +143,12 @@ css framework, please see [documentation in the Wiki pages](https://github.com/r
 ### Javascript
 ```javascript
 //vue-table dependencies (vue and vue-resource)
-<script src="https://cdn.jsdelivr.net/vue/1.0.28/vue.js"></script>
-<script src="https://cdn.jsdelivr.net/vue.resource/1.0.3/vue-resource.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/vue@1.0.28/dist/vue.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/vue-resource@1.0.3/dist/vue-resource.min.js"></script>
 
-<script type="text/javascript" src="http://cdn.jsdelivr.net/vue.table/1.5.3/vue-table.min.js"></script>
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/vuetable@1.5.12/dist/vue-table.min.js"></script>
 //or
-<script type="text/javascript" src="http://cdn.jsdelivr.net/vue.table/1.5.3/vue-table.js"></script>
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/vuetable@1.5.12/dist/vue-table.js"></script>
 ```
 
 ### Bower


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the links now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/vuetable.

Feel free to ping me if you have any questions regarding this change.